### PR TITLE
Updated semicolons to colons to work on linux machine in grade.sh

### DIFF
--- a/grade.sh
+++ b/grade.sh
@@ -1,4 +1,4 @@
-CPATH='.;../lib/hamcrest-core-1.3.jar;../lib/junit-4.13.2.jar'
+CPATH='.:../lib/hamcrest-core-1.3.jar:../lib/junit-4.13.2.jar'
 
 rm -rf student-submission
 git clone $1 student-submission 2> ta-output.txt


### PR DESCRIPTION
I recognize that you have this change performed in your own device, so this pull request might be entirely redundant.